### PR TITLE
Added a feature: 'Local Image Uploader'

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <application
         android:label="m_flow"
         android:name="${applicationName}"

--- a/lib/pages/extra.dart
+++ b/lib/pages/extra.dart
@@ -872,3 +872,89 @@
 //     );
 //   }
 // }
+
+
+                    
+                  //   IconButton(
+                  //     onPressed: () async {
+                  //       final ImagePicker _picker = ImagePicker();
+                  //       final XFile? image = await _picker.pickImage(source: ImageSource.gallery);
+                  //       if (image != null) {
+                  //         // Store the image temporarily
+                  //         final Directory tempDir = await getTemporaryDirectory();
+                  //         final File tempImage = await File(image.path).copy('${tempDir.path}/temp_image.jpg');
+                  //         final String url = 'file://${tempImage.path}';
+                  //         print(url);
+                  //         final HttpServer server = await HttpServer.bind('localhost', 8080, shared: true);
+                  //         server.listen((HttpRequest request) {
+                  //           final File imageFile = File(tempImage.path);
+                  //           request.response.headers.contentType = ContentType('image', 'jpeg');
+                  //           imageFile.openRead().pipe(request.response).catchError((e) {
+                  //             request.response.statusCode = HttpStatus.internalServerError;
+                  //             request.response.close();
+                  //           });
+                  //         });
+
+                  //         final Uri url1 = Uri.parse('http://localhost:8080/temp_image.jpg');
+                  //         print('Image can be accessed at: $url1');
+                  //       }
+                  //     }, icon: const Icon(Icons.upload_file)
+                  //   )
+                  // ]),
+
+
+
+
+
+
+
+
+
+
+
+//                   Make sure to add the necessary permissions to your AndroidManifest.xml file to read and write files:
+
+// xml
+
+// Verify
+
+// Open In Editor
+// Edit
+// Copy code
+// <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+// <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+// This should allow you to store the image in the app's directory and use it in your markdown content.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  // Future<void> _handleUploadImage() async {
+  //   try {
+  //     final image = await ImagePicker().pickImage(source: ImageSource.gallery);
+  //     if (image!= null) {
+  //       final directory = await getApplicationDocumentsDirectory();
+  //       final file = File('${directory.path}/image.png');
+  //       await file.writeAsBytes(await image.readAsBytes());
+  //       final imageData = await file.readAsBytes();
+  //       final imagePath = file.path;
+  //       setState(() {
+  //         // final markdownText = '![Image](data:image/png;base64,${base64Encode(imageData)})';
+  //         final markdownTex = '![Image]($imagePath)';
+  //         leftController.text += markdownTex;
+  //       });
+  //     }
+  //   } catch (e) {
+  //     print('Error: $e');
+  //     // Handle the error, e.g., show an error message to the user
+  //   }
+  // }

--- a/lib/pages/information.dart
+++ b/lib/pages/information.dart
@@ -4,7 +4,7 @@ class InfoPage extends StatelessWidget{
   @override
   Widget build(BuildContext context) {
     ScrollController w = ScrollController();
-    String s = "M-Flow 0.1-Alpha, By Native Bits Team\n\n Developers:\n Imad Laggoune | Project Manager and Lead Developer\n Madhur | Lead Developer\n\n Licenes:\nflutter_markdown: BSD-3, License Text:\n";
+    String s = "M-Flow 0.1-Alpha, By Native Bits Team\n\n Developers:\n Imad Laggoune | Project Manager and Lead Developer\n Madhur pandey | Lead Developer\n\n Licenes:\nflutter_markdown: BSD-3, License Text:\n";
     s += loadLicenseBSDThree();
     s += "\n md2pdf: MIT, License Text:";
     s += loadLicenseMIT();

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 #include <printing/printing_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) printing_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "PrintingPlugin");
   printing_plugin_register_with_registrar(printing_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
   printing
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import file_selector_macos
+import path_provider_foundation
 import printing
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.0.6"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "045d372bf19b02aeb69cacf8b4009555fb5f6f0b7ad8016e5f46dd1387ddd492"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.2+1"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: f42eacb83b318e183b1ae24eead1373ab1334084404c8c16e0354f9a3e55d385
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: d3547240c20cabf205c7c7f01a50ecdbc413755814d6677f3cb366f04abcead0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -172,10 +204,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
+      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   http_parser:
     dependency: transitive
     description:
@@ -184,6 +216,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  http_server:
+    dependency: "direct main"
+    description:
+      name: http_server
+      sha256: f1fd4de4f57ba5597fddf8029bc0d161e9151a69e1d87ccddec901d2b5a45b10
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   image:
     dependency: transitive
     description:
@@ -192,6 +232,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: ff39a10ab4f48f4ac70776d0494a97bf073cd2570892cd46bc8a5cac162c25db
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+4"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "5d6eb13048cd47b60dbf1a5495424dea226c5faf3950e20bf8120a58efb5b5f3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.4"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "6703696ad49f5c3c8356d576d7ace84d1faf459afb07accbb0fae780753ff447"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "4ed1d9bb36f7cd60aa6e6cd479779cc56a4cb4e4de8f49d487b1aaad831300fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "3f5ad1e8112a9a6111c46d0b57a7be2286a9a07fc6e1976fdf5be2bd31d4ff62"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "9ec26d410ff46f483c5519c29c02ef0e02e13a543f882b152d4bfd2f06802f80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.0"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   leak_tracker:
     dependency: transitive
     description:
@@ -256,6 +360,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   path:
     dependency: transitive
     description:
@@ -272,6 +384,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "30c5aa827a6ae95ce2853cdc5fe3971daaac00f6f081c419c013f7f57bff2f5e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.7"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   pdf:
     dependency: "direct main"
     description:
@@ -296,6 +456,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -316,10 +484,10 @@ packages:
     dependency: transitive
     description:
       name: qr
-      sha256: "64957a3930367bf97cc211a5af99551d630f2f4625e38af10edd6b19131b64b3"
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -413,6 +581,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.5.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,10 @@ dependencies:
   markdown: ^7.2.2
   pdf: ^3.11.0
   printing: ^5.13.1
+  image_picker: ^1.1.2
+  path_provider: ^2.0.11
+  http_server: ^1.0.0
+
   
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_windows/file_selector_windows.h>
 #include <printing/printing_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   PrintingPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PrintingPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_windows
   printing
 )
 


### PR DESCRIPTION
**Local Image Uploader**:

- This feature allows users to seamlessly upload images from their device's gallery into their Markdown documents. 
- Upon selecting an image, it is stored locally within the application's directory, and a pre-filled Markdown image syntax is automatically generated and inserted into the document. 
- This enhancement streamlines the process of embedding images.

**Implementation Details**:

- The implementation leverages the image_picker package to allow users to select an image from their gallery. 
- Once an image is selected, it is saved to the application's documents directory with a unique filename generated using a **timestamp**. 
- The file's URI is then used to create the Markdown image syntax, which is automatically inserted into the document.

- By writing the image's bytes to a file in one line (```await file.writeAsBytes(await image.readAsBytes());```), We efficiently save the selected image locally by directly reading the image's bytes and immediately writing them to the new file. This ensures minimal processing overhead and speeds up the operation, making the process quick and straightforward.

**TODO**:
- Images are not loading in the preview as of now, So we need to work on this now...